### PR TITLE
Update fitting code

### DIFF
--- a/SuperMonoJet/fitting/hadd_fittingforest.sh
+++ b/SuperMonoJet/fitting/hadd_fittingforest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash                                                                                                                                                                                         
+
+ANALYSIS=$1
+
+mkdir -p $ANALYSIS
+
+declare -A array=( [signal]=met [wmn]=singlemu [tmn]=singlemu [tme]=singlemu [wen]=singleele [ten]=singleele [tem]=singleele [zmm]=dimu [zee]=diele [pho]=pho )
+
+BASE_COMMAND='hadd fittingForest_'
+DIR=/uscms_data/d3/ahall/panda/80X-v1.4/boosted_met/flat/limits
+
+if [ $ANALYSIS != 'monojet' ]
+then
+FAIL_COMMAND="hadd ${ANALYSIS}/fittingForest_${ANALYSIS}_doublebf.root "
+PASS_COMMAND="hadd ${ANALYSIS}/fittingForest_${ANALYSIS}_doublebp.root "
+    for SEL in signal wmn wen tmn ten zmm zee pho
+    do
+	FAIL_COMMAND="${FAIL_COMMAND} ${DIR}/fittingForest_${SEL}_fail.root"
+	PASS_COMMAND="${FAIL_COMMAND} ${DIR}/fittingForest_${SEL}.root"
+    done
+echo "Here is the hadd command you should run:"
+echo $FAIL_COMMAND
+echo $PASS_COMMAND
+fi
+
+if [ $ANALYSIS == 'monojet' ]
+then
+    echo "Cannot handle monojet right now."
+fi
+

--- a/SuperMonoJet/fitting/launch_fittingforest.sh
+++ b/SuperMonoJet/fitting/launch_fittingforest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash                                                                                                                                                                                         
+
+ANALYSIS=$1
+
+declare -A array=( [signal]=met [wmn]=singlemu [tmn]=singlemu [tme]=singlemu [wen]=singleele [ten]=singleele [tem]=singleele [zmm]=dimu [zee]=diele [pho]=pho )
+
+if [ $ANALYSIS != 'monojet' ]
+then
+#    for SEL in signal wmn wen tmn ten zmm zee pho
+    for SEL in ten 
+    do
+	source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_fail
+    done
+
+    for SEL in zmm zee pho
+    do
+	source makeFittingForest.sh $ANALYSIS ${array[$SEL]} $SEL 
+	source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_fail 
+    done
+fi
+
+if [ $ANALYSIS == 'monojet' ]
+then
+    for SEL in signal wmn wen tmn ten zmm zee pho tme tem
+    do
+#            echo -e "source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_$TAG $FROMLIMIT"      
+	source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_0tag 
+        source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_1tag 
+        source makeFittingForest.sh $ANALYSIS ${array[$SEL]} ${SEL}_2tag 
+    done
+fi

--- a/SuperMonoJet/fitting/makeFittingForest.py
+++ b/SuperMonoJet/fitting/makeFittingForest.py
@@ -179,13 +179,9 @@ elif 'pho' in region:
     factory.add_process(f('QCD'),'QCD')
 
 
-elif 'signal' not in region:
-    factory.add_process(f('ZtoNuNu'),'Zvv')
+else:
     factory.add_process(f('ZJets'),'Zll')
-    factory.add_process(f('WJets'),'Wlv')
-    factory.add_process(f('SingleTop'),'ST')
     factory.add_process(f('Diboson'),'Diboson')
-    factory.add_process(f('QCD'),'QCD')
     factory.add_process(f('TTbar'),'ttbar')
 
     if 'zee' in region or 'te' in region or 'wen' in region:
@@ -193,16 +189,16 @@ elif 'signal' not in region:
 
     if 'zmm' in region or 'tm' in region or 'wmn' in region:
         factory.add_process(f('MET'),'Data',is_data=True,extra_cut=sel.metTrigger)
-	
-elif 'signal' in region:
-    factory.add_process(f('MET'),'Data',is_data=True,extra_cut=sel.metTrigger)
-    factory.add_process(f('ZtoNuNu'),'Zvv')
-    factory.add_process(f('TTbar'),'ttbar')
-    factory.add_process(f('ZJets'),'Zll')
-    factory.add_process(f('WJets'),'Wlv')
-    factory.add_process(f('SingleTop'),'ST')
-    factory.add_process(f('Diboson'),'Diboson')
-    factory.add_process(f('QCD'),'QCD')
+    
+    if 'signal' in region or 'te' in region or 'wen' in region or 'tm' in region or 'wmn' in region:
+        factory.add_process(f('WJets'),'Wlv')
+        factory.add_process(f('SingleTop'),'ST')
+        factory.add_process(f('QCD'),'QCD')
+        if 'signal' in region:
+            factory.add_process(f('MET'),'Data',is_data=True,extra_cut=sel.metTrigger)
+            factory.add_process(f('ZtoNuNu'),'Zvv')
+
+
 
 forestDir = basedir + '/limits/'
 os.system('mkdir -p %s'%(forestDir))


### PR DESCRIPTION
I made a launch_fittingforest.sh script to run makeFittingForest.sh to create all of the necessary trees. Afterwards, the hadd_fittingforest.sh script can be used to consolidate all of the forests into two root files for failed and passed b-tag categories (although note that for testing purposes, I just printed the command to run, instead of running it directly). 

I also edited makeFittingForest.py to have the proper map of processes and regions. At some point this should be centralized so we don't have to maintain it in each script.